### PR TITLE
Updating docker-compose to version 2.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
-version: '3'
+version: "2.4"
 
 services:
   public-node:
     container_name: public-node
     image: ltonetwork/public-node
-    mem_limit: 1g
+    mem_reservation: 1g
     volumes:
       - ./volumes/public-node:/lto
     ports:


### PR DESCRIPTION
- Updates `docker-compose` to use version 2.4
- Adds `mem_reservation` instead of `mem_limit`